### PR TITLE
fix: Update vector syntax

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  MINIMUM_NOIR_VERSION: v0.36.0
+  MINIMUM_NOIR_VERSION: v1.0.0-beta.19
 
 jobs:
   noir-version-list:

--- a/src/lib.nr
+++ b/src/lib.nr
@@ -1,7 +1,7 @@
 pub mod quicksort;
 use crate::quicksort::quicksort::quicksort as quicksort;
 use crate::quicksort::quicksort_explicit::quicksort as quicksort_explicit;
-use dep::check_shuffle::{check_shuffle, get_shuffle_indices};
+use ::check_shuffle::{check_shuffle, get_shuffle_indices};
 
 /**
  * Given an input array of type T, return a sorted array.

--- a/src/quicksort/quicksort.nr
+++ b/src/quicksort/quicksort.nr
@@ -23,7 +23,7 @@ unconstrained fn quicksort_loop<T, let N: u32>(arr: &mut [T; N], low: u32, high:
 where
     T: std::cmp::Ord,
 {
-    let mut stack: [(u32, u32)] = &[(low, high)];
+    let mut stack: [(u32, u32)] = @[(low, high)];
     // TODO(https://github.com/noir-lang/noir_sort/issues/22): use 'loop' once it's stabilized
     for _ in 0..2 * N {
         if stack.len() == 0 {

--- a/src/quicksort/quicksort.nr
+++ b/src/quicksort/quicksort.nr
@@ -55,4 +55,3 @@ where
     }
     arr
 }
-

--- a/src/quicksort/quicksort_explicit.nr
+++ b/src/quicksort/quicksort_explicit.nr
@@ -27,7 +27,7 @@ unconstrained fn quicksort_loop<T, let N: u32>(
     high: u32,
     sortfn: unconstrained fn(T, T) -> bool,
 ) {
-    let mut stack: [(u32, u32)] = &[(low, high)];
+    let mut stack: [(u32, u32)] = @[(low, high)];
     // TODO(https://github.com/noir-lang/noir_sort/issues/22): use 'loop' once it's stabilized
     for _ in 0..2 * N {
         if stack.len() == 0 {


### PR DESCRIPTION
## Problem Resolved

Resolves <!-- Link to GitHub Issue -->

## Summary of Changes

This repo still uses the deprecated vector syntax which is being removed in https://github.com/noir-lang/noir/pull/12740

## PR Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.


BEGIN_COMMIT_OVERRIDE
fix!: Update vector syntax (#25)
END_COMMIT_OVERRIDE